### PR TITLE
Parse C++17 nested namespace declarations

### DIFF
--- a/src/libclang/namespace_parser.cpp
+++ b/src/libclang/namespace_parser.cpp
@@ -24,7 +24,9 @@ namespace
         if (skip_if(stream, "inline"))
             is_inline = true;
 
-        // C++17 nested namespace declarations
+        // C++17 nested namespace declarations get one cursor per nested name.
+        // The first cursor starts with the `namespace` keyword, and the
+        // following start with the `::` separator. Either way, it is skipped.
         if (!detail::skip_if(stream, "namespace"))
           skip(stream, "::");
 
@@ -40,7 +42,8 @@ namespace
         auto other_attributes = parse_attributes(stream);
         attributes.insert(attributes.end(), other_attributes.begin(), other_attributes.end());
 
-        // C++17 nested namespace declarations
+        // If the next token is not `::`, there are no more nested namespace
+        // names, and we expect to see an opening brace.
         if (!detail::skip_if(stream, "::"))
           skip(stream, "{");
 

--- a/src/libclang/namespace_parser.cpp
+++ b/src/libclang/namespace_parser.cpp
@@ -18,13 +18,16 @@ namespace
     {
         detail::cxtokenizer    tokenizer(context.tu, context.file, cur);
         detail::cxtoken_stream stream(tokenizer, cur);
-        // [inline] namespace [<attribute>] <identifier> {
+        // [inline] namespace|:: [<attribute>] <identifier> [{]
 
         auto is_inline = false;
         if (skip_if(stream, "inline"))
             is_inline = true;
 
-        skip(stream, "namespace");
+        // C++17 nested namespace declarations
+        if (!detail::skip_if(stream, "namespace"))
+          skip(stream, "::");
+
         auto attributes = parse_attributes(stream);
 
         // <identifier> {
@@ -37,7 +40,9 @@ namespace
         auto other_attributes = parse_attributes(stream);
         attributes.insert(attributes.end(), other_attributes.begin(), other_attributes.end());
 
-        skip(stream, "{");
+        // C++17 nested namespace declarations
+        if (!detail::skip_if(stream, "::"))
+          skip(stream, "{");
 
         auto result = cpp_namespace::builder(name.c_str(), is_inline);
         result.get().add_attribute(attributes);

--- a/test/cpp_namespace.cpp
+++ b/test/cpp_namespace.cpp
@@ -33,6 +33,16 @@ namespace c
 /// namespace {
 /// }
 namespace {}
+
+/// namespace e{
+///   namespace f{
+///   }
+/// }
+namespace e::f {}
+
+/// \entity e::f
+/// namespace f{
+/// }
 )";
 
     auto file  = parse({}, "cpp_namespace.cpp", code);
@@ -66,6 +76,19 @@ namespace {}
         else if (ns.name() == "")
         {
             REQUIRE(ns.is_anonymous());
+            REQUIRE(!ns.is_inline());
+            REQUIRE(no_children == 0u);
+        }
+        else if (ns.name() == "e")
+        {
+            REQUIRE(!ns.is_anonymous());
+            REQUIRE(!ns.is_inline());
+            REQUIRE(no_children == 1u);
+        }
+        else if (ns.name() == "f")
+        {
+            REQUIRE(!ns.is_anonymous());
+            check_parent(ns, "e", "e::f");
             REQUIRE(!ns.is_inline());
             REQUIRE(no_children == 0u);
         }


### PR DESCRIPTION
This is maybe not the most correct way to do it, but i dont think it misparses
any valid code. Tested on [topisani/OTTO](https://github.com/topisani/OTTO), and seems to work.