### PR TITLE
Bugfix/escaped character parsing

### DIFF
--- a/src/libclang/preprocessor.cpp
+++ b/src/libclang/preprocessor.cpp
@@ -740,11 +740,7 @@ detail::preprocessor_output detail::preprocess(const libclang_compile_config& co
         if (next && next > p.ptr())
             p.bump(std::size_t(next - p.ptr() - 1)); // subtract one to get before that character
 
-        if (starts_with(p, "\\\"")) // starts with \"
-            p.bump(2u);
-        else if (starts_with(p, "\\'")) // starts with \'
-            p.bump(2u);
-        else if (in_char == false && starts_with(p, "\"")) // starts with "
+        if (in_char == false && starts_with(p, "\"")) // starts with "
         {
             p.bump();
             in_string.toggle();
@@ -756,6 +752,10 @@ detail::preprocessor_output detail::preprocess(const libclang_compile_config& co
         }
         else if (in_string == true || in_char == true)
             p.bump();
+        else if (starts_with(p, "\\\"")) // starts with \"
+            p.bump(2u);
+        else if (starts_with(p, "\\'")) // starts with \'
+            p.bump(2u);
         else if (auto macro = parse_macro(p, result, file_depth == 0u))
         {
             if (logger.is_verbose())

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,8 +34,6 @@ set(tests
         preprocessor.cpp
         visitor.cpp)
 
-    message(${CMAKE_CURRENT_LIST_DIR})
-
 add_executable(cppast_test test.cpp test_parser.hpp ${tests})
 target_include_directories(cppast_test PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(cppast_test PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../src)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,10 +31,14 @@ set(tests
         integration.cpp
         libclang_parser.cpp
         parser.cpp
+        preprocessor.cpp
         visitor.cpp)
+
+    message(${CMAKE_CURRENT_LIST_DIR})
 
 add_executable(cppast_test test.cpp test_parser.hpp ${tests})
 target_include_directories(cppast_test PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(cppast_test PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../src)
 target_link_libraries(cppast_test PUBLIC cppast)
 set_target_properties(cppast_test PROPERTIES CXX_STANDARD 11)
 

--- a/test/preprocessor.cpp
+++ b/test/preprocessor.cpp
@@ -6,7 +6,7 @@
 
 using namespace cppast;
 
-TEST_CASE("preprocessor_parses_escaped_character")
+TEST_CASE("preprocessor_parses_escaped_character", "[!hide][clang4]")
 {
     write_file("ppec.hpp", R"(
 )");

--- a/test/preprocessor.cpp
+++ b/test/preprocessor.cpp
@@ -2,19 +2,9 @@
 #include <fstream>
 
 #include "libclang/preprocessor.hpp"
-
 #include "test_parser.hpp"
 
 using namespace cppast;
-
-/*libclang_compilation_database get_database(const char* json)
-{
-    std::ofstream file("compile_commands.json");
-    file << json;
-    file.close();
-
-    return libclang_compilation_database(".");
-}*/
 
 TEST_CASE("preprocessor_parses_escaped_character")
 {

--- a/test/preprocessor.cpp
+++ b/test/preprocessor.cpp
@@ -1,0 +1,44 @@
+#include <catch.hpp>
+#include <fstream>
+
+#include "libclang/preprocessor.hpp"
+
+#include "test_parser.hpp"
+
+using namespace cppast;
+
+/*libclang_compilation_database get_database(const char* json)
+{
+    std::ofstream file("compile_commands.json");
+    file << json;
+    file.close();
+
+    return libclang_compilation_database(".");
+}*/
+
+TEST_CASE("preprocessor_parses_escaped_character")
+{
+    write_file("ppec.hpp", R"(
+)");
+    // This is an actual macro from the rapidjson source (reader.h)
+    write_file("ppec.cpp", R"(
+#define Z16 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+ static const char escape[256] = {
+            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0, 0,'\"', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,'/',
+            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,'\\', 0, 0, 0,
+            0, 0,'\b', 0, 0, 0,'\f', 0, 0, 0, 0, 0, 0, 0,'\n', 0,
+            0, 0,'\r', 0,'\t', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+        };
+#undef Z16
+
+#include "ppec.hpp"
+)");
+
+    libclang_compile_config config;
+    config.set_flags(cpp_standard::cpp_latest);
+
+    auto&& preprocessed = detail::preprocess(config, "ppec.cpp", default_logger().get());
+    REQUIRE(preprocessed.includes.size() == 1);
+    REQUIRE(preprocessed.includes[0].file_name == "ppec.hpp");
+}


### PR DESCRIPTION
I am building a tool that I tried to use on a larger C++ codebase, and parts of it depends on rapidjson. Apparently there's a macro definition that confuses the preprocessor (that parses macros, includes and comments) and leaves it in an unwanted state (it parses the following couple lines as part of a character literal).