### PR TITLE
Change "odd flag" criteria on preprocessor command flags

### DIFF
--- a/src/libclang/preprocessor.cpp
+++ b/src/libclang/preprocessor.cpp
@@ -227,7 +227,7 @@ namespace
         for (const auto& flag : detail::libclang_compile_config_access::flags(c))
         {
             DEBUG_ASSERT(flag.size() > 2u && flag[0] == '-', detail::assert_handler{},
-                         "that's an odd flag");
+                         ("\"" + flag + "\" that's an odd flag").c_str());
             if (!macro_file_path || flag[1] != 'I')
             {
                 // only add this flag if it is not an include or we're not doing fast preprocessing

--- a/src/libclang/preprocessor.cpp
+++ b/src/libclang/preprocessor.cpp
@@ -226,7 +226,7 @@ namespace
         // other flags
         for (const auto& flag : detail::libclang_compile_config_access::flags(c))
         {
-            DEBUG_ASSERT(flag.size() > 2u && flag[0] == '-', detail::assert_handler{},
+            DEBUG_ASSERT(flag.size() >= 2u && flag[0] == '-', detail::assert_handler{},
                          ("\"" + flag + "\" that's an odd flag").c_str());
             if (!macro_file_path || flag[1] != 'I')
             {


### PR DESCRIPTION
The assert on libclang/preprocessor.cpp:263 fails with common flags
such as "-g", because the assertion says valid flags must have at least
three characters.

I've changed that condition to accept two char flags like -g.

I've also added the flag to the assertion diagnostic, to help with debugging.