### PR TITLE
Ignore git tags in llvm-config version numbers

### DIFF
--- a/external/external.cmake
+++ b/external/external.cmake
@@ -122,6 +122,10 @@ function(_cppast_find_libclang config_tool min_version force)
     # check version
     execute_process(COMMAND ${LLVM_CONFIG_BINARY} --version
                     OUTPUT_VARIABLE llvm_version OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    # Ignore git tags in the version string, get the semver number only
+    string(REGEX REPLACE "([0-9]).([0-9]).([0-9])(.*)" "\\1.\\2.\\3" llvm_version "${llvm_version}")
+
     if(llvm_version VERSION_LESS min_version)
         message(FATAL_ERROR "Outdated LLVM version ${llvm_version}, minimal supported is ${min_version}")
     else()


### PR DESCRIPTION
Some llvm precompiled releases, such as 5.0.0 have a git tag as part of
the version number given by their llvm-config, but the rest of the setup
(for example, the system includes directory) uses the semantic
versioning tag ("5.0.0") only.

This commit adds a regex filter to ignore any tag appended to the llvm
version number, if any.

See [this build](https://gitlab.com/Manu343726/tinyrefl/-/jobs/88434002) for an example of the issue.