### PR TITLE
Use ull hashes to be compatible with 32 bit builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,16 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
+          packages: ['g++-5-multilib', 'gcc-5-multilib', 'lcov', 'llvm-4.0', 'clang-4.0', 'libclang-4.0-dev']
+      env: TOOLSET=g++-5 m32=-m32 CPPAST_TEST_GCOV=ON LLVM_VERSION=4.0 LLVM_CONFIG_BINARY=/usr/bin/llvm-config-4.0
+
+    - os: linux
+      dist: trusty
+      sudo: false
+      compiler: gcc
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
           packages: ['g++-5', 'lcov', 'llvm-4.0', 'clang-4.0', 'libclang-4.0-dev']
       env: TOOLSET=g++-5 CPPAST_TEST_GCOV=ON LLVM_VERSION=4.0 LLVM_CONFIG_BINARY=/usr/bin/llvm-config-4.0
 
@@ -72,7 +82,7 @@ install:
 
 script:
   - mkdir build/ && cd build/
-  - $CMAKE -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-Werror -pedantic -Wall -Wextra -Wconversion -Wsign-conversion -Wno-parentheses -Wno-assume" ../ -DCPPAST_TEST_GCOV=$CPPAST_TEST_GCOV -DLLVM_CONFIG_BINARY=$LLVM_CONFIG_BINARY
+  - $CMAKE -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-Werror -pedantic -Wall -Wextra -Wconversion -Wsign-conversion -Wno-parentheses -Wno-assume $m32" ../ -DCPPAST_TEST_GCOV=$CPPAST_TEST_GCOV -DLLVM_CONFIG_BINARY=$LLVM_CONFIG_BINARY
   - $CMAKE --build .
   - if [[ "$LLVM_VERSION" == "4.0" ]]; then ./test/cppast_test \*; else ./test/cppast_test; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-4.0']
-          packages: ['g++-5-multilib', 'gcc-5-multilib', 'lcov', 'llvm-4.0', 'clang-4.0', 'libclang-4.0-dev']
+          packages: ['g++-5-multilib', 'gcc-5-multilib', 'linux-libc-dev:i386', 'lcov', 'llvm-4.0', 'clang-4.0', 'libclang-4.0-dev']
       env: TOOLSET=g++-5 m32=-m32 CPPAST_TEST_GCOV=ON LLVM_VERSION=4.0 LLVM_CONFIG_BINARY=/usr/bin/llvm-config-4.0
 
     - os: linux

--- a/include/cppast/cpp_entity_index.hpp
+++ b/include/cppast/cpp_entity_index.hpp
@@ -23,20 +23,22 @@ namespace cppast
     /// \exclude
     namespace detail
     {
-        constexpr std::size_t fnv_basis = 14695981039346656037ull;
-        constexpr std::size_t fnv_prime = 1099511628211ull;
+        using hash_t = unsigned long long;
+
+        constexpr hash_t fnv_basis = 14695981039346656037ull;
+        constexpr hash_t fnv_prime = 1099511628211ull;
 
         // FNV-1a 64 bit hash
-        constexpr std::size_t id_hash(const char* str, std::size_t hash = fnv_basis)
+        constexpr hash_t id_hash(const char* str, hash_t hash = fnv_basis)
         {
-            return *str ? id_hash(str + 1, (hash ^ std::size_t(*str)) * fnv_prime) : hash;
+            return *str ? id_hash(str + 1, (hash ^ hash_t(*str)) * fnv_prime) : hash;
         }
     } // namespace detail
 
     /// A [ts::strong_typedef]() representing the unique id of a [cppast::cpp_entity]().
     ///
     /// It is comparable for equality.
-    struct cpp_entity_id : type_safe::strong_typedef<cpp_entity_id, std::size_t>,
+    struct cpp_entity_id : type_safe::strong_typedef<cpp_entity_id, detail::hash_t>,
                            type_safe::strong_typedef_op::equality_comparison<cpp_entity_id>
     {
         explicit cpp_entity_id(const std::string& str) : cpp_entity_id(str.c_str()) {}
@@ -117,9 +119,9 @@ namespace cppast
     private:
         struct hash
         {
-            std::size_t operator()(const cpp_entity_id& id) const noexcept
+            detail::hash_t operator()(const cpp_entity_id& id) const noexcept
             {
-                return static_cast<std::size_t>(id);
+                return static_cast<detail::hash_t>(id);
             }
         };
 


### PR DESCRIPTION
The bug (#66)  is fixed ([Before](https://travis-ci.org/Manu343726/cppast/jobs/420839701), [after](https://travis-ci.org/Manu343726/cppast/jobs/420843912)), but before merging we should figure out a way to handle non-host arch builds: Build only? Download and link with 32 bit llvm?.