### PR TITLE
Add handling of -isystem include flag

### DIFF
--- a/src/libclang/libclang_parser.cpp
+++ b/src/libclang/libclang_parser.cpp
@@ -222,6 +222,8 @@ libclang_compile_config::libclang_compile_config(const libclang_compilation_data
         parse_flags(cmd, [&](std::string flag, std::string args) {
             if (flag == "-I")
                 add_flag(std::move(flag) + get_full_path(dir, args));
+            else if (flag == "-isystem")
+                add_flag(std::move(flag) + get_full_path(dir, args));
             else if (flag == "-D" || flag == "-U")
             {
                 // preprocessor options


### PR DESCRIPTION
`-isystem` include flags from `compile_commands.json` are currently ignored. This patch fixes that.

`-isystem` acts much like `-I`, but causes the compiler to not emit warnings for files in those directories.
