### PR TITLE
Use empty underlying type for aliases of anonymous types

### DIFF
--- a/src/libclang/type_parser.cpp
+++ b/src/libclang/type_parser.cpp
@@ -637,7 +637,7 @@ std::unique_ptr<cpp_type> parse_type_impl(const detail::parse_context& context, 
     case CXType_Typedef:
         return make_leave_type(cur, type, [&](std::string&& spelling) {
             auto decl = clang_getTypeDeclaration(type);
-            if (remove_prefix(spelling, "(anonymous", false))
+            if (detail::cxstring(clang_getCursorSpelling(decl)).empty())
                 spelling = ""; // anonymous type
             return cpp_user_defined_type::build(
                 cpp_type_ref(detail::get_entity_id(decl), std::move(spelling)));

--- a/test/cpp_type_alias.cpp
+++ b/test/cpp_type_alias.cpp
@@ -509,7 +509,7 @@ typedef decltype(0) w;
         }
         else if (alias.name() == "v")
         {
-            auto type = cpp_user_defined_type::build(cpp_type_ref(cpp_entity_id(""), "v"));
+            auto type = cpp_user_defined_type::build(cpp_type_ref(cpp_entity_id(""), ""));
             REQUIRE(equal_types(idx, alias.underlying_type(), *type));
             return false;
         }


### PR DESCRIPTION
Fixes https://github.com/foonathan/cppast/issues/58#issuecomment-405194360.

The issue appears to be caused by `clang_getTypeSpelling` not returning empty on type aliases for anonymous types. Getting spelling at the time of declaration by using `clang_getCursorSpelling` on declaration cursor instead worked out well.

Test file:
```cpp
// test.hpp

typedef enum {
} TypedefedAnonEnum;

typedef struct {
} TypedefedAnonStruct;

enum NormalEnum {
};
typedef enum NormalEnum NormalEnum;

struct NormalStruct {
    struct {

    } UnnamedStruct;
    struct {
        int anonymous_struct_member;
    };
};
typedef NormalStruct NormalStruct;
typedef NormalStruct TypedefedNormalStruct;
```

Before Patch:
```
$ tool/cppast -v test.hpp
[libclang parser] [debug] test.hpp:1: parsing cursor of type 'EnumDecl'
[libclang parser] [debug] test.hpp:2: parsing cursor of type 'TypedefDecl'
[libclang parser] [debug] test.hpp:4: parsing cursor of type 'StructDecl'
[libclang parser] [debug] test.hpp:5: parsing cursor of type 'TypedefDecl'
[libclang parser] [debug] test.hpp:7: parsing cursor of type 'EnumDecl'
[libclang parser] [debug] test.hpp:9: parsing cursor of type 'TypedefDecl'
[libclang parser] [debug] test.hpp:11: parsing cursor of type 'StructDecl'
[libclang parser] [debug] test.hpp:12: parsing cursor of type 'StructDecl'
[libclang parser] [debug] test.hpp:14: parsing cursor of type 'FieldDecl'
[libclang parser] [debug] test.hpp:15: parsing cursor of type 'StructDecl'
[libclang parser] [debug] test.hpp:16: parsing cursor of type 'FieldDecl'
[libclang parser] [debug] test.hpp:19: parsing cursor of type 'TypedefDecl'
[libclang parser] [debug] test.hpp:20: parsing cursor of type 'TypedefDecl'
AST for 'test.hpp':
|-<anonymous> (enum) [definition]: `enum ;`
|-TypedefedAnonEnum (type alias): `using TypedefedAnonEnum=enum TypedefedAnonEnum;`
|-<anonymous> (class) [definition]: `struct ;`
|-TypedefedAnonStruct (type alias): `using TypedefedAnonStruct=TypedefedAnonStruct;`
|-NormalEnum (enum) [definition]: `enum NormalEnum;`
|-NormalEnum (type alias): `using NormalEnum=enum NormalEnum;`
|-NormalStruct (class) [definition]: `struct NormalStruct;`
| |-<anonymous> (class) [definition]: `struct ;`
| |-UnnamedStruct (member variable): ` UnnamedStruct;`
| +-<anonymous> (class) [definition]: `struct ;`
|   +-anonymous_struct_member (member variable): `int anonymous_struct_member;`
|-NormalStruct (type alias): `using NormalStruct=NormalStruct;`
+-TypedefedNormalStruct (type alias): `using TypedefedNormalStruct=NormalStruct;`
```

After Patch:
```
$ tool/cppast -v test.hpp
[libclang parser] [debug] test.hpp:1: parsing cursor of type 'EnumDecl'
[libclang parser] [debug] test.hpp:2: parsing cursor of type 'TypedefDecl'
[libclang parser] [debug] test.hpp:4: parsing cursor of type 'StructDecl'
[libclang parser] [debug] test.hpp:5: parsing cursor of type 'TypedefDecl'
[libclang parser] [debug] test.hpp:7: parsing cursor of type 'EnumDecl'
[libclang parser] [debug] test.hpp:9: parsing cursor of type 'TypedefDecl'
[libclang parser] [debug] test.hpp:11: parsing cursor of type 'StructDecl'
[libclang parser] [debug] test.hpp:12: parsing cursor of type 'StructDecl'
[libclang parser] [debug] test.hpp:14: parsing cursor of type 'FieldDecl'
[libclang parser] [debug] test.hpp:15: parsing cursor of type 'StructDecl'
[libclang parser] [debug] test.hpp:16: parsing cursor of type 'FieldDecl'
[libclang parser] [debug] test.hpp:19: parsing cursor of type 'TypedefDecl'
[libclang parser] [debug] test.hpp:20: parsing cursor of type 'TypedefDecl'
AST for 'test.hpp':
|-<anonymous> (enum) [definition]: `enum ;`
|-TypedefedAnonEnum (type alias): `using TypedefedAnonEnum=;`
|-<anonymous> (class) [definition]: `struct ;`
|-TypedefedAnonStruct (type alias): `using TypedefedAnonStruct=;`
|-NormalEnum (enum) [definition]: `enum NormalEnum;`
|-NormalEnum (type alias): `using NormalEnum=enum NormalEnum;`
|-NormalStruct (class) [definition]: `struct NormalStruct;`
| |-<anonymous> (class) [definition]: `struct ;`
| |-UnnamedStruct (member variable): ` UnnamedStruct;`
| +-<anonymous> (class) [definition]: `struct ;`
|   +-anonymous_struct_member (member variable): `int anonymous_struct_member;`
|-NormalStruct (type alias): `using NormalStruct=NormalStruct;`
+-TypedefedNormalStruct (type alias): `using TypedefedNormalStruct=NormalStruct;`
```

Output Diff:
```diff
16c16
< |-TypedefedAnonEnum (type alias): `using TypedefedAnonEnum=enum TypedefedAnonEnum;`
---
> |-TypedefedAnonEnum (type alias): `using TypedefedAnonEnum=;`
18c18
< |-TypedefedAnonStruct (type alias): `using TypedefedAnonStruct=TypedefedAnonStruct;`
---
> |-TypedefedAnonStruct (type alias): `using TypedefedAnonStruct=;`
```

Snippet to check if an alias is for an anonymous type:

```cpp
bool is_alias_for_anonymous(const cpp_type_alias& e) {
    auto& ut = e.underlying_type();
    if (ut.kind() == cpp_type_kind::user_defined_t) {
        auto& alias_of = static_cast<const cpp_user_defined_type&>(ut);
        return alias_of.entity().name().empty();
    }
    return false;
}
```

I didn't test this for templated typedefs, not sure if templated anonymous types make sense somehow.

BTW, this is an awesome library. I enjoyed delving into its details. Thanks.

ps. Tested with clang version 7.0.1-8 (tags/RELEASE_701/final).