### PR TITLE
Fix redundant std::move() errors with GCC 9. Fixes #89

### DIFF
--- a/src/libclang/namespace_parser.cpp
+++ b/src/libclang/namespace_parser.cpp
@@ -126,7 +126,7 @@ std::unique_ptr<cpp_entity> detail::parse_cpp_namespace_alias(const detail::pars
     auto result = cpp_namespace_alias::build(*context.idx, get_entity_id(cur), std::move(name),
                                              std::move(target));
     context.comments.match(*result, cur);
-    return std::move(result);
+    return result;
 }
 
 std::unique_ptr<cpp_entity> detail::parse_cpp_using_directive(const detail::parse_context& context,
@@ -149,7 +149,7 @@ std::unique_ptr<cpp_entity> detail::parse_cpp_using_directive(const detail::pars
     auto target = cpp_namespace_ref(parse_ns_target_cursor(cur), std::move(target_name));
     auto result = cpp_using_directive::build(target);
     context.comments.match(*result, cur);
-    return std::move(result);
+    return result;
 }
 
 namespace
@@ -221,5 +221,5 @@ std::unique_ptr<cpp_entity> detail::parse_cpp_using_declaration(
     auto target = parse_entity_target_cursor(cur, std::move(target_name));
     auto result = cpp_using_declaration::build(std::move(target));
     context.comments.match(*result, cur);
-    return std::move(result);
+    return result;
 }

--- a/src/libclang/parse_functions.cpp
+++ b/src/libclang/parse_functions.cpp
@@ -284,5 +284,5 @@ std::unique_ptr<cpp_entity> detail::parse_cpp_static_assert(const detail::parse_
 
     auto result = cpp_static_assert::build(std::move(expr), std::move(msg));
     context.comments.match(*result, cur);
-    return std::move(result);
+    return result;
 }

--- a/src/libclang/preprocessor.cpp
+++ b/src/libclang/preprocessor.cpp
@@ -135,7 +135,7 @@ ts::optional<std::string> parse_missing_file(const std::string& cur_file, const 
     ++ptr;
 
     if (std::strcmp(ptr, " file not found") == 0)
-        return std::move(filename);
+        return filename;
     else
         throw libclang_error("preprocessor: unexpected diagnostic '" + msg + "'");
 }

--- a/src/libclang/template_parser.cpp
+++ b/src/libclang/template_parser.cpp
@@ -114,7 +114,7 @@ std::unique_ptr<cpp_template_parameter> parse_non_type_parameter(
                                                          detail::parse_type(context, cur, type),
                                                          is_variadic, std::move(def));
     result->add_attribute(attributes);
-    return std::move(result);
+    return result;
 }
 
 std::unique_ptr<cpp_template_template_parameter> parse_template_parameter(

--- a/src/libclang/type_parser.cpp
+++ b/src/libclang/type_parser.cpp
@@ -725,5 +725,5 @@ std::unique_ptr<cpp_entity> detail::parse_cpp_type_alias(const detail::parse_con
         result->add_attribute(detail::parse_attributes(stream));
     }
 
-    return std::move(result);
+    return result;
 }

--- a/src/libclang/variable_parser.cpp
+++ b/src/libclang/variable_parser.cpp
@@ -84,7 +84,7 @@ std::unique_ptr<cpp_entity> detail::parse_cpp_variable(const detail::parse_conte
                                                  storage_class, is_constexpr);
     context.comments.match(*result, cur);
     result->add_attribute(attributes);
-    return std::move(result);
+    return result;
 }
 
 std::unique_ptr<cpp_entity> detail::parse_cpp_member_variable(const detail::parse_context& context,
@@ -117,5 +117,5 @@ std::unique_ptr<cpp_entity> detail::parse_cpp_member_variable(const detail::pars
     }
     result->add_attribute(attributes);
     context.comments.match(*result, cur);
-    return std::move(result);
+    return result;
 }


### PR DESCRIPTION
See #89 

**EDIT**: Just noticed this PR is a duplicate of #84. The fix is working for me, and I'm not directly affected by this not being merged (I work with my fork and its packaged conan version). Do whatever you want with this PR :)