### PR TITLE
Fix MSVC warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,4 +117,4 @@ target_compile_options(cppast PRIVATE
                            $<$<CXX_COMPILER_ID:GNU>: -Wno-noexcept-type>
                            # MSVC warnings
                            $<$<CXX_COMPILER_ID:MSVC>:
-                           /WX /W4>)
+                           /W3>)


### PR DESCRIPTION
/WX Treats all compiler warnings as errors. It should be disabled to prevent compilation issues with CMake on Windows.

/W4 displays level 1, level 2, and level 3 warnings, and all level 4 (informational) warnings that aren't off by default. /W3 is the default setting in the IDE and should be enforced to prevent issues with CMake.