### PR TITLE
Segfault when parsing an empty extern "C" {} block

### DIFF
--- a/src/cpp_language_linkage.cpp
+++ b/src/cpp_language_linkage.cpp
@@ -15,7 +15,11 @@ cpp_entity_kind cpp_language_linkage::kind() noexcept
 
 bool cpp_language_linkage::is_block() const noexcept
 {
-    DEBUG_ASSERT(begin() != end(), detail::assert_handler{}, "empty container");
+    if (begin() == end())
+    {
+        // An empty container must be a "block" of the form: extern "C" {}
+        return true;
+    }
     return std::next(begin()) != end(); // more than one entity, so block
 }
 

--- a/test/cpp_language_linkage.cpp
+++ b/test/cpp_language_linkage.cpp
@@ -36,6 +36,8 @@ extern "C++" // yup
     enum e {};
 }
 
+extern "C" {}
+
 enum f {};
 )";
 

--- a/test/cpp_language_linkage.cpp
+++ b/test/cpp_language_linkage.cpp
@@ -36,7 +36,9 @@ extern "C++" // yup
     enum e {};
 }
 
-extern "C" {}
+/// extern "C++"{
+/// }
+extern "C++" {}
 
 enum f {};
 )";
@@ -52,7 +54,7 @@ enum f {};
         else
             REQUIRE(false);
     });
-    REQUIRE(count == 2u);
+    REQUIRE(count == 3u);
 
     // check enums for their correct parent
     count = test_visit<cpp_enum>(*file,


### PR DESCRIPTION
extern declaration blocks can be empty: https://en.cppreference.com/w/cpp/language/language_linkage