### PR TITLE
[WIP] Add better C support

### DIFF
--- a/include/cppast/compile_config.hpp
+++ b/include/cppast/compile_config.hpp
@@ -15,7 +15,7 @@
 
 namespace cppast
 {
-/// The C++ standard that should be used.
+/// The C/C++ standard that should be used.
 enum class cpp_standard
 {
     cpp_98,
@@ -26,8 +26,14 @@ enum class cpp_standard
     cpp_17,
     cpp_2a,
     cpp_20,
+    c_89,
+    c_99,
+    c_11,
+    c_17,
+    c_2x,
 
     cpp_latest = cpp_standard::cpp_14, //< The latest supported C++ standard.
+    c_latest = cpp_standard::c_17, //< The latest supported C standard.
 };
 
 /// \returns A human readable string representing the option,
@@ -52,10 +58,80 @@ inline const char* to_string(cpp_standard standard) noexcept
         return "c++2a";
     case cpp_standard::cpp_20:
         return "c++20";
+    case cpp_standard::c_89:
+        return "c89";
+    case cpp_standard::c_99:
+        return "c99";
+    case cpp_standard::c_11:
+        return "c11";
+    case cpp_standard::c_17:
+        return "c17";
+    case cpp_standard::c_2x:
+        return "c2x";
     }
 
     DEBUG_UNREACHABLE(detail::assert_handler{});
     return "ups";
+}
+
+/// \returns The C/C++ standard corresponding to the string, e.g. `cpp_14` for `c++14`
+/// \throws std::invalid_argument for an unknown language standard
+inline cpp_standard to_standard(const std::string& str)
+{
+    if (str == "c++98")
+        return cpp_standard::cpp_98;
+    else if (str == "c++03")
+        return cpp_standard::cpp_03;
+    else if (str == "c++11")
+        return cpp_standard::cpp_11;
+    else if (str == "c++14")
+        return cpp_standard::cpp_14;
+    else if (str == "c++1z")
+        return cpp_standard::cpp_1z;
+    else if (str == "c++17")
+        return cpp_standard::cpp_17;
+    else if (str == "c++2a")
+        return cpp_standard::cpp_2a;
+    else if (str == "c++20")
+        return cpp_standard::cpp_20;
+    else if (str == "c89")
+        return cpp_standard::c_89;
+    else if (str == "c99")
+        return cpp_standard::c_99;
+    else if (str == "c11")
+        return cpp_standard::c_11;
+    else if (str == "c17")
+        return cpp_standard::c_17;
+    else if (str == "c2x")
+        return cpp_standard::c_2x;
+    else
+        throw std::invalid_argument("invalid C/C++ standard '" + str + "'");
+}
+
+/// \returns whether the language standard is a C standard
+inline bool is_c_standard(cpp_standard standard) noexcept
+{
+    switch (standard)
+    {
+    case cpp_standard::cpp_98:
+    case cpp_standard::cpp_03:
+    case cpp_standard::cpp_11:
+    case cpp_standard::cpp_14:
+    case cpp_standard::cpp_1z:
+    case cpp_standard::cpp_17:
+    case cpp_standard::cpp_2a:
+    case cpp_standard::cpp_20:
+        return false;
+    case cpp_standard::c_89:
+    case cpp_standard::c_99:
+    case cpp_standard::c_11:
+    case cpp_standard::c_17:
+    case cpp_standard::c_2x:
+        return true;
+    }
+
+    DEBUG_UNREACHABLE(detail::assert_handler{});
+    return false;
 }
 
 /// Other special compilation flags.
@@ -114,6 +190,12 @@ public:
         return do_get_name();
     }
 
+    /// \returns Whether to parse files as C rather than C++.
+    bool use_c() const noexcept
+    {
+        return do_use_c();
+    }
+
 protected:
     compile_config(std::vector<std::string> def_flags) : flags_(std::move(def_flags)) {}
 
@@ -156,6 +238,9 @@ private:
     /// \returns A unique name of the configuration.
     /// \notes This allows detecting mismatches of configurations and parsers.
     virtual const char* do_get_name() const noexcept = 0;
+
+    /// \returns Whether to parse files as C rather than C++.
+    virtual bool do_use_c() const noexcept = 0;
 
     std::vector<std::string> flags_;
 };

--- a/include/cppast/cpp_storage_class_specifiers.hpp
+++ b/include/cppast/cpp_storage_class_specifiers.hpp
@@ -19,10 +19,16 @@ enum cpp_storage_class_specifiers : int
 
     cpp_storage_class_auto = 1, //< *automatic* storage duration.
 
-    cpp_storage_class_static = 2, //< *static* or *thread* storage duration and *internal* linkage.
-    cpp_storage_class_extern = 4, //< *static* or *thread* storage duration and *external* linkage.
 
-    cpp_storage_class_thread_local = 8, //< *thread* storage duration.
+    cpp_storage_class_register = 2, //< *automatic* storage duration.
+    /// Hints to the compiler to keep this in a register.
+    /// \notes In C a register variable cannot have its address taken. For C++ `register` is
+    /// deprecated in C++11 and removed in C++17.
+
+    cpp_storage_class_static = 4, //< *static* or *thread* storage duration and *internal* linkage.
+    cpp_storage_class_extern = 8, //< *static* or *thread* storage duration and *external* linkage.
+
+    cpp_storage_class_thread_local = 16, //< *thread* storage duration.
     /// \notes This is the only one that can be combined with the others.
 };
 
@@ -49,6 +55,13 @@ inline bool is_extern(cpp_storage_class_specifiers spec) noexcept
 {
     return (spec & cpp_storage_class_extern) != 0;
 }
+
+/// \returns Whether the [cppast::cpp_storage_class_specifiers]() contain `register`.
+inline bool is_register(cpp_storage_class_specifiers spec) noexcept
+{
+    return (spec & cpp_storage_class_register) != 0;
+}
 } // namespace cppast
+
 
 #endif // CPPAST_CPP_STORAGE_CLASS_SPECIFIERS_HPP_INCLUDED

--- a/include/cppast/cpp_type.hpp
+++ b/include/cppast/cpp_type.hpp
@@ -289,7 +289,6 @@ private:
 /// Flags for the kinds of C/C++ qualifiers.
 enum cpp_cv_flags : int
 {
-    cpp_cv_none, //< unqualified type
     cpp_cv_const, //< constant type
     cpp_cv_volatile, //< volatile type
     cpp_cv_restrict, //< restrict pointer type (C-only)
@@ -300,6 +299,11 @@ enum cpp_cv_flags : int
 
 /// Flag set for the kinds for C/C++ qualifiers.
 using cpp_cv = type_safe::flag_set<cpp_cv_flags>;
+
+/// Represents a const volatile qualified type
+constexpr cpp_cv cpp_cv_const_volatile = cpp_cv(cpp_cv_const) | cpp_cv_volatile;
+/// Represents an unqualified type
+constexpr cpp_cv cpp_cv_none = cpp_cv();
 
 /// \returns `true` if the qualifier contains `const`.
 inline bool is_const(const cpp_cv& cv) noexcept

--- a/include/cppast/cpp_type.hpp
+++ b/include/cppast/cpp_type.hpp
@@ -286,25 +286,43 @@ private:
     std::unique_ptr<cpp_type> dependee_;
 };
 
-/// The kinds of C++ cv qualifiers.
-enum cpp_cv : int
+/// Flags for the kinds of C/C++ qualifiers.
+enum cpp_cv_flags : int
 {
-    cpp_cv_none,
-    cpp_cv_const,
-    cpp_cv_volatile,
-    cpp_cv_const_volatile,
+    cpp_cv_none, //< unqualified type
+    cpp_cv_const, //< constant type
+    cpp_cv_volatile, //< volatile type
+    cpp_cv_restrict, //< restrict pointer type (C-only)
+    cpp_cv_atomic, //< atomic type (C-only)
+
+    _flag_set_size, //< \exclude
 };
 
+/// Flag set for the kinds for C/C++ qualifiers.
+using cpp_cv = type_safe::flag_set<cpp_cv_flags>;
+
 /// \returns `true` if the qualifier contains `const`.
-inline bool is_const(cpp_cv cv) noexcept
+inline bool is_const(const cpp_cv& cv) noexcept
 {
-    return cv == cpp_cv_const || cv == cpp_cv_const_volatile;
+    return (cv & cpp_cv_const) != 0;
 }
 
 /// \returns `true` if the qualifier contains `volatile`.
-inline bool is_volatile(cpp_cv cv) noexcept
+inline bool is_volatile(const cpp_cv& cv) noexcept
 {
-    return cv == cpp_cv_volatile || cv == cpp_cv_const_volatile;
+    return (cv & cpp_cv_volatile) != 0;
+}
+
+/// \returns `true` if the qualifier contains `restrict`.
+inline bool is_restrict(const cpp_cv& cv) noexcept
+{
+    return (cv & cpp_cv_restrict) != 0;
+}
+
+/// \returns `true` if the qualifier contains `atomic`.
+inline bool is_atomic(const cpp_cv& cv) noexcept
+{
+    return (cv & cpp_cv_atomic) != 0;
 }
 
 /// A [cppast::cpp_cv]() qualified [cppast::cpp_type]().
@@ -354,6 +372,12 @@ const cpp_type& remove_const(const cpp_type& type) noexcept;
 
 /// \returns The type without top-level volatile qualifiers.
 const cpp_type& remove_volatile(const cpp_type& type) noexcept;
+
+/// \returns The type without top-level restrict qualifiers.
+const cpp_type& remove_restrict(const cpp_type& type) noexcept;
+
+/// \returns The type without top-level atomic qualifiers.
+const cpp_type& remove_atomic(const cpp_type& type) noexcept;
 
 /// A pointer to a [cppast::cpp_type]().
 class cpp_pointer_type final : public cpp_type

--- a/include/cppast/cppast_fwd.hpp
+++ b/include/cppast/cppast_fwd.hpp
@@ -102,7 +102,7 @@ enum class visit_filter;
 
 enum cpp_access_specifier_kind : int;
 enum cpp_builtin_type_kind : int;
-enum cpp_cv : int;
+enum cpp_cv_flags : int;
 enum cpp_function_body_kind : int;
 enum cpp_reference : int;
 enum cpp_storage_class_specifiers : int;

--- a/include/cppast/libclang_parser.hpp
+++ b/include/cppast/libclang_parser.hpp
@@ -166,10 +166,13 @@ private:
         return "libclang";
     }
 
+    bool do_use_c() const noexcept override;
+
     std::string clang_binary_;
     bool        write_preprocessed_ : 1;
     bool        fast_preprocessing_ : 1;
     bool        remove_comments_in_macro_ : 1;
+    bool        use_c_     : 1;
 
     friend detail::libclang_compile_config_access;
 };

--- a/src/code_generator.cpp
+++ b/src/code_generator.cpp
@@ -682,6 +682,7 @@ bool write_cv_ref(code_generator::output& output, const cpp_member_function_base
             output << whitespace;
         output << keyword(std::move(q));
         first = false;
+        need_ws = true;
     }
 
     switch (base.ref_qualifier())

--- a/src/code_generator.cpp
+++ b/src/code_generator.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2017-2022 Jonathan Müller and cppast contributors
 // SPDX-License-Identifier: MIT
 
+#include "cppast/cpp_type.hpp"
 #include <cppast/code_generator.hpp>
 
 #include <cppast/cpp_alias_template.hpp>
@@ -471,6 +472,8 @@ void write_storage_class(code_generator::output& output, cpp_storage_class_speci
         output << keyword("extern") << whitespace;
     if (is_thread_local(storage))
         output << keyword("thread_local") << whitespace;
+    if (is_register(storage))
+        output << keyword("register") << whitespace;
     if (is_constexpr)
         output << keyword("constexpr") << whitespace;
     else if (is_consteval)

--- a/src/code_generator.cpp
+++ b/src/code_generator.cpp
@@ -661,22 +661,27 @@ void write_suffix_virtual(code_generator::output& output, const cpp_virtual& vir
 bool write_cv_ref(code_generator::output& output, const cpp_member_function_base& base)
 {
     auto need_ws = false;
-    switch (base.cv_qualifier())
+    auto cv = base.cv_qualifier();
+
+    std::vector<const char*> qualifiers;
+    if (is_const(cv))
+        qualifiers.push_back("const");
+    if (is_volatile(cv))
+        qualifiers.push_back("volatile");
+    if (is_atomic(cv))
+        qualifiers.push_back("_Atomic");
+    if (is_restrict(cv))
+        qualifiers.push_back("restrict");
+
+    bool first = true;
+    for (auto& q : qualifiers)
     {
-    case cpp_cv_none:
-        break;
-    case cpp_cv_const:
-        output << operator_ws << keyword("const");
-        need_ws = true;
-        break;
-    case cpp_cv_volatile:
-        output << operator_ws << keyword("volatile");
-        need_ws = true;
-        break;
-    case cpp_cv_const_volatile:
-        output << operator_ws << keyword("const") << whitespace << keyword("volatile");
-        need_ws = true;
-        break;
+        if (first)
+            output << operator_ws;
+        else
+            output << whitespace;
+        output << keyword(std::move(q));
+        first = false;
     }
 
     switch (base.ref_qualifier())

--- a/src/cpp_member_function.cpp
+++ b/src/cpp_member_function.cpp
@@ -15,6 +15,10 @@ std::string cpp_member_function_base::do_get_signature() const
         result += " const";
     if (is_volatile(cv_qualifier()))
         result += " volatile";
+    if (is_atomic(cv_qualifier()))
+        result += " _Atomic";
+    if (is_restrict(cv_qualifier()))
+        result += " restrict";
 
     if (ref_qualifier() == cpp_ref_lvalue)
         result += " &";

--- a/src/cpp_type.cpp
+++ b/src/cpp_type.cpp
@@ -1,6 +1,7 @@
 // Copyright (C) 2017-2022 Jonathan Müller and cppast contributors
 // SPDX-License-Identifier: MIT
 
+#include "cppast/code_generator.hpp"
 #include <cppast/cpp_type.hpp>
 
 #include <cppast/cpp_array_type.hpp>
@@ -11,6 +12,7 @@
 #include <cppast/cpp_function_type.hpp>
 #include <cppast/cpp_template.hpp>
 #include <cppast/cpp_type_alias.hpp>
+#include <vector>
 
 using namespace cppast;
 
@@ -103,6 +105,28 @@ const cpp_type& cppast::remove_volatile(const cpp_type& type) noexcept
     {
         auto& cv = static_cast<const cpp_cv_qualified_type&>(type);
         if (is_volatile(cv.cv_qualifier()))
+            return cv.type();
+    }
+    return type;
+}
+
+const cpp_type& cppast::remove_restrict(const cpp_type& type) noexcept
+{
+    if (type.kind() == cpp_type_kind::cv_qualified_t)
+    {
+        auto& cv = static_cast<const cpp_cv_qualified_type&>(type);
+        if (is_restrict(cv.cv_qualifier()))
+            return cv.type();
+    }
+    return type;
+}
+
+const cpp_type& cppast::remove_atomic(const cpp_type& type) noexcept
+{
+    if (type.kind() == cpp_type_kind::cv_qualified_t)
+    {
+        auto& cv = static_cast<const cpp_cv_qualified_type&>(type);
+        if (is_atomic(cv.cv_qualifier()))
             return cv.type();
     }
     return type;
@@ -283,6 +307,10 @@ void write_cv_qualified_prefix(code_generator::output& output, const cpp_cv_qual
         output << whitespace << keyword("const");
     if (is_volatile(type.cv_qualifier()))
         output << whitespace << keyword("volatile");
+    if (is_atomic(type.cv_qualifier()))
+        output << whitespace << keyword("_Atomic");
+    if (is_restrict(type.cv_qualifier()))
+        output << whitespace << keyword("restrict");
 }
 
 void write_cv_qualified_suffix(code_generator::output& output, const cpp_cv_qualified_type& type)
@@ -435,16 +463,28 @@ void write_member_function_suffix(code_generator::output&         output,
     output << bracket_ws << punctuation(")");
     write_parameters(output, type);
 
-    auto cv  = cpp_cv_none;
-    auto ref = cpp_ref_none;
+    cpp_cv cv = cpp_cv_none;
+    auto ref  = cpp_ref_none;
     strip_class_type(type.class_type(), &cv, &ref);
 
-    if (cv == cpp_cv_const_volatile)
-        output << keyword("const") << whitespace << keyword("volatile");
-    else if (is_const(cv))
-        output << keyword("const");
-    else if (is_volatile(cv))
-        output << keyword("volatile");
+    std::vector<const char*> qualifiers;
+    if (is_const(cv))
+        qualifiers.push_back("const");
+    if (is_volatile(cv))
+        qualifiers.push_back("volatile");
+    if (is_atomic(cv))
+        qualifiers.push_back("_Atomic");
+    if (is_restrict(cv))
+        qualifiers.push_back("restrict");
+
+    bool first = true;
+    for (auto& q : qualifiers)
+    {
+        if (!first)
+            output << whitespace;
+        output << keyword(std::move(q));
+        first = false;
+    }
 
     if (ref == cpp_ref_lvalue)
         output << operator_ws << punctuation("&") << operator_ws;

--- a/src/libclang/function_parser.cpp
+++ b/src/libclang/function_parser.cpp
@@ -327,22 +327,24 @@ struct suffix_info
 
 cpp_cv parse_cv(detail::cxtoken_stream& stream)
 {
-    if (detail::skip_if(stream, "const"))
-    {
-        if (detail::skip_if(stream, "volatile"))
-            return cpp_cv_const_volatile;
-        else
-            return cpp_cv_const;
-    }
-    else if (detail::skip_if(stream, "volatile"))
+    bool found_qualifier = true;
+    cpp_cv qualifier = cpp_cv_none;
+
+    while (found_qualifier)
     {
         if (detail::skip_if(stream, "const"))
-            return cpp_cv_const_volatile;
+            qualifier |= cpp_cv_const;
+        else if (detail::skip_if(stream, "volatile"))
+            qualifier |= cpp_cv_volatile;
+        else if (detail::skip_if(stream, "restrict"))
+            qualifier |= cpp_cv_restrict;
+        else if (detail::skip_if(stream, "_Atomic"))
+            qualifier |= cpp_cv_atomic;
         else
-            return cpp_cv_volatile;
+            found_qualifier = false;
     }
-    else
-        return cpp_cv_none;
+
+    return qualifier;
 }
 
 cpp_reference parse_ref(detail::cxtoken_stream& stream)

--- a/src/libclang/libclang_parser.cpp
+++ b/src/libclang/libclang_parser.cpp
@@ -194,7 +194,23 @@ void parse_flags(CXCompileCommand cmd, Func callback)
         }
         else if (!last_flag.empty())
         {
-            callback(std::move(last_flag), str.std_str());
+            // we have flags + args
+            std::string args;
+            if (auto ptr = find_flag_arg_sep(last_flag))
+            {
+                // If last flag contains an '=' then this is a positional argument, not its value
+                auto pos = std::size_t(ptr - last_flag.c_str());
+                ++ptr;
+                while (*ptr)
+                    args += *ptr++;
+                last_flag.erase(pos);
+
+                callback(std::move(last_flag), std::move(args));
+            }
+            else
+            {
+                callback(std::move(last_flag), str.std_str());
+            }
             last_flag.clear();
         }
         // else skip argument

--- a/src/libclang/parse_functions.cpp
+++ b/src/libclang/parse_functions.cpp
@@ -57,8 +57,10 @@ cpp_storage_class_specifiers detail::get_storage_class(const CXCursor& cur)
         return cpp_storage_class_none;
 
     case CX_SC_Auto:
-    case CX_SC_Register:
         return cpp_storage_class_auto;
+
+    case CX_SC_Register:
+        return cpp_storage_class_register;
 
     case CX_SC_Extern:
         return cpp_storage_class_extern;

--- a/src/libclang/preprocessor.cpp
+++ b/src/libclang/preprocessor.cpp
@@ -165,11 +165,12 @@ std::string diagnostics_flags()
 // get the command that returns all macros defined in the TU
 std::string get_macro_command(const libclang_compile_config& c, const char* full_path)
 {
-    // -x c++: force C++ as input language
+    // -xc/-xc++: force C or C++ as input language
     // -I.: add current working directory to include search path
     // -E: print preprocessor output
     // -dM: print macro definitions instead of preprocessed file
-    auto flags = std::string("-x c++ -I. -E -dM");
+    std::string language = c.use_c() ? "-xc" : "-xc++";
+    auto flags = language + " -I. -E -dM";
     flags += diagnostics_flags();
 
     std::string cmd(detail::libclang_compile_config_access::clang_binary(c) + " " + std::move(flags)
@@ -189,10 +190,11 @@ std::string get_macro_command(const libclang_compile_config& c, const char* full
 std::string get_preprocess_command(const libclang_compile_config& c, const char* full_path,
                                    const char* macro_file_path)
 {
-    // -x c++: force C++ as input language
+    // -xc/-xc++: force C or C++ as input language
     // -E: print preprocessor output
     // -dD: keep macros
-    auto flags = std::string("-x c++ -E -dD");
+    std::string language = c.use_c() ? "-xc" : "-xc++";
+    auto flags = language + " -E -dD";
 
     // -CC: keep comments, even in macro
     // -C: keep comments, but not in macro

--- a/src/libclang/variable_parser.cpp
+++ b/src/libclang/variable_parser.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<cpp_entity> detail::parse_cpp_variable(const detail::parse_conte
     // can't appear anywhere else, so good enough
     detail::cxtokenizer tokenizer(context.tu, context.file, cur);
     for (auto& token : tokenizer)
-        if (token.value() == "thread_local")
+        if (token.value() == "thread_local" || token.value() == "_Thread_local")
             storage_class
                 = cpp_storage_class_specifiers(storage_class | cpp_storage_class_thread_local);
         else if (token.value() == "constexpr")

--- a/test/parser.cpp
+++ b/test/parser.cpp
@@ -27,6 +27,11 @@ TEST_CASE("parse_files")
         {
             return "null";
         }
+
+        bool do_use_c() const noexcept override
+        {
+            return false;
+        }
     } config;
 
     class null_parser : public parser


### PR DESCRIPTION
Better C support as discussed in standardese/standardese#220. 

Added:
* `restrict` & `_Atomic` qualifiers
* `register` storage class
* C's `_Thread_local` as an alias for C++'s `thread_local`
* Support for parsing C files as C so libclang doesn't complain when these are used

Also fixed an issue that was causing my `compile_commands.json` to parse incorrectly. It was treating `... -std=c17 filename.c` as if `filename.c` was the value for `-std=c17` rather than splitting `-std=c17` and treating `filename.c` as a positional argument.

This PR is still a work in progress, but I think most of the changes required for C support are there if you want to review them. I have generally kept naming as is, so `cpp_standard` now includes both C and C++ standards, and `cpp_cv` has all 4 qualifiers, not just const and volatile.

I still have some issues using Standardese with some of my C code. For example:
```c
/// docs
typedef enum { ... } name_t;
```
This generates documentation for the anonymous struct rather than the typedef. An easy workaround is:
```c
enum _name { ... };
/// docs
typedef enum _name name_t;
```
But in this case the docs show `using name_t = _name;` which is only valid in C++, rather than a typedef which is standard C.

I haven't looked into these remaining issues yet; if they originate from [foonathan/cppast](https://github.com/foonathan/cppast) or whether only [standardese/standardese](https://github.com/standardese/standardese) needs some more changes.