### PR TITLE
Fixed virtual inheritance parsing

### DIFF
--- a/src/libclang/class_parser.cpp
+++ b/src/libclang/class_parser.cpp
@@ -98,11 +98,22 @@ void add_base_class(cpp_class::builder& builder, const detail::parse_context& co
     detail::cxtoken_stream stream(tokenizer, cur);
 
     // [<attribute>] [virtual] [<access>] <name>
+    // or
+    // [<attribute>] [<access>] [virtual] <name>
     // can't use spelling to get the name
     auto attributes = detail::parse_attributes(stream);
     if (is_virtual)
-        detail::skip(stream, "virtual");
-    detail::skip_if(stream, to_string(access));
+    {
+        if (detail::skip_if(stream, "virtual"))
+            detail::skip_if(stream, to_string(access));
+        else
+        {
+            detail::skip_if(stream, to_string(access));
+            detail::skip(stream, "virtual");
+        }
+    }
+    else
+        detail::skip_if(stream, to_string(access));
 
     auto name = detail::to_string(stream, stream.end()).as_string();
 

--- a/test/cpp_class.cpp
+++ b/test/cpp_class.cpp
@@ -84,6 +84,13 @@ struct f
 : public ns::base, virtual protected e
 {};
 
+/// struct f2
+/// :ns::base,virtual protected e{
+/// };
+struct f2
+: public ns::base, protected virtual e
+{};
+
 using namespace ns;
 
 /// struct g
@@ -234,7 +241,7 @@ struct g
             }
             REQUIRE(no_bases == 2u);
         }
-        else if (c.name() == "f")
+        else if (c.name() == "f" || c.name() == "f2")
         {
             REQUIRE(c.is_definition());
             REQUIRE(!c.is_declaration());
@@ -298,5 +305,5 @@ struct g
         else
             REQUIRE(false);
     });
-    REQUIRE(count == 12u);
+    REQUIRE(count == 13u);
 }


### PR DESCRIPTION
This PR fixes parsing of virtual inheritance specification. 

Currently only the following order is supported `[virtual] [<access>]`, while according to ISO and most compilers it also legal to place the `virtual` keyword after the access specifier, i.e. both `virtual public` and `public virtual` should be allowed.

The extended test case in `test/cpp_class.cpp` fails without this fix...