### PR TITLE
Fixed files with backslashes not reporting any items

### DIFF
--- a/include/cppast/detail/intrusive_list.hpp
+++ b/include/cppast/detail/intrusive_list.hpp
@@ -29,6 +29,18 @@ namespace detail
 
         template <typename U>
         friend struct intrusive_list_access;
+
+    public:
+        ~intrusive_list_node() noexcept
+        {
+            // free iteratively to avoid stack overflow in debug builds
+            T* next = next_.release();
+            while ( next )
+            {
+                std::unique_ptr<T> cur( next );
+                next = cur->next_.release();
+            }
+        }
     };
 
     template <typename T>

--- a/src/libclang/preprocessor.cpp
+++ b/src/libclang/preprocessor.cpp
@@ -1023,8 +1023,11 @@ ts::optional<linemarker> parse_linemarker(position& p)
     std::string file_name;
     for (; !starts_with(p, "\""); p.skip())
     {
-        if (*p.ptr() == '\\')
-            file_name += "\\\\";
+        if ( starts_with( p, "\\\\" ) )
+        {
+            file_name += "\\";
+            p.skip();
+        }
         else
             file_name += *p.ptr();
     }


### PR DESCRIPTION
parse_linemarker was turning double backslashes into quadruple backslashes. Making it instead turn them into single backslashes makes the "lm.value().file == path" comparison true in preprocess() so that p.enable_write() is called.

fixes foonathan/cppast#106