### PR TITLE
Pass custom clang binary path to clang compile config constructor

### DIFF
--- a/include/cppast/libclang_parser.hpp
+++ b/include/cppast/libclang_parser.hpp
@@ -95,6 +95,13 @@ public:
     /// and `__cppast_minor__`.
     libclang_compile_config();
 
+    /// Create the default configuration, using a custom path to the clang binary
+    /// \effects It will set the clang binary as passed, or will search for it as normal if not found
+    /// as well as the libclang system include directory determined by the build system.
+    /// It will also define `__cppast__` with the value `"libclang"` as well as `__cppast_major__`
+    /// and `__cppast_minor__`.
+    libclang_compile_config(std::string clang_binary);
+
     /// Creates the configuration stored in the database.
     ///
     /// \effects It will use the options found in the database for the specified file.
@@ -108,6 +115,20 @@ public:
     /// \notes The file key will include the specified directory in the JSON, if it is not a full
     /// path.
     libclang_compile_config(const libclang_compilation_database& database, const std::string& file);
+
+    /// Creates the configuration stored in the database, using a custom path to the clang binary
+    ///
+    /// \effects It will use the options found in the database for the specified file.
+    /// This does not necessarily need to match the file that is going to be parsed,
+    /// but it should.
+    /// It will also add the default configuration options.
+    /// \notes Header files are not included in the compilation database,
+    /// you need to pass in the file name of the corresponding source file,
+    /// if you want to parse one.
+    /// \notes It will only consider options you could also set by the other functions.
+    /// \notes The file key will include the specified directory in the JSON, if it is not a full
+    /// path.
+    libclang_compile_config(std::string clang_binary, const libclang_compilation_database& database, const std::string& file);
 
     libclang_compile_config(const libclang_compile_config& other) = default;
     libclang_compile_config& operator=(const libclang_compile_config& other) = default;

--- a/src/libclang/libclang_parser.cpp
+++ b/src/libclang/libclang_parser.cpp
@@ -78,12 +78,14 @@ bool libclang_compilation_database::has_config(const char* file_name) const
 namespace
 {} // namespace
 
-libclang_compile_config::libclang_compile_config()
+libclang_compile_config::libclang_compile_config() : libclang_compile_config(CPPAST_CLANG_BINARY) {}
+
+libclang_compile_config::libclang_compile_config(std::string clang_binary)
 : compile_config({}), write_preprocessed_(false), fast_preprocessing_(false),
   remove_comments_in_macro_(false)
 {
     // set given clang binary
-    set_clang_binary(CPPAST_CLANG_BINARY);
+    set_clang_binary(clang_binary);
 
     // set macros to detect cppast
     define_macro("__cppast__", "libclang");
@@ -205,7 +207,14 @@ void parse_flags(CXCompileCommand cmd, Func callback)
 
 libclang_compile_config::libclang_compile_config(const libclang_compilation_database& database,
                                                  const std::string&                   file)
-: libclang_compile_config()
+: libclang_compile_config(CPPAST_CLANG_BINARY, database, file)
+{}
+
+
+cppast::libclang_compile_config::libclang_compile_config(
+    std::string clang_binary, const libclang_compilation_database& database,
+    const std::string& file)
+: libclang_compile_config(clang_binary)
 {
     auto cxcommands
         = clang_CompilationDatabase_getCompileCommands(database.database_, file.c_str());


### PR DESCRIPTION
Currently the both constructors of `libclang_compile_config` use the clang binary defined in project setup. While this is fine for many applications, it means that any binaries that might be used across multiple machines may end up with an incorrect path to the clang binary, rendering it impossible to create instances of `libclang_compile_config` at all (since an exception is thrown during construction). This adds new versions of both constructors that can be passed a string containing the path to a clang binary, which will be used instead of the `CPPAST_CLANG_BINARY` macro.