### PR TITLE
fixed build error in MSVC in certain configurations

### DIFF
--- a/include/cppast/code_generator.hpp
+++ b/include/cppast/code_generator.hpp
@@ -63,7 +63,7 @@ namespace detail
     {
     public:
         template <typename T>
-        explicit semantic_string_view(T&& obj, decltype(string_view(std::forward<T>(obj)), 0) = 0)
+        explicit semantic_string_view(T&& obj, decltype(string_view(std::declval<T>()), 0) = 0)
         : str_(std::forward<T>(obj))
         {}
 


### PR DESCRIPTION
Fixed issue when building in MSVC with strict conformance mode enabled or when targetting C++20 and later, applying the same fix from [here](https://github.com/foonathan/type_safe/commit/5e7db9afaa05fe0495de1bb53415960456ea3910)