### PR TITLE
Add c++2b as a permitted language version

### DIFF
--- a/include/cppast/compile_config.hpp
+++ b/include/cppast/compile_config.hpp
@@ -26,6 +26,7 @@ enum class cpp_standard
     cpp_17,
     cpp_2a,
     cpp_20,
+    cpp_2b,
 
     cpp_latest = cpp_standard::cpp_14, //< The latest supported C++ standard.
 };
@@ -52,6 +53,8 @@ inline const char* to_string(cpp_standard standard) noexcept
         return "c++2a";
     case cpp_standard::cpp_20:
         return "c++20";
+    case cpp_standard::cpp_2b:
+        return "c++2b";
     }
 
     DEBUG_UNREACHABLE(detail::assert_handler{});

--- a/src/libclang/libclang_parser.cpp
+++ b/src/libclang/libclang_parser.cpp
@@ -415,6 +415,15 @@ void libclang_compile_config::do_set_flags(cpp_standard standard, compile_flags 
         }
         else
             throw std::invalid_argument("c++20 is not yet supported for current version of clang");
+    case cpp_standard::cpp_2b:
+        if (libclang_parser::libclang_minor_version() >= 61)
+        { // Corresponds to Clang version 12
+            if (flags & compile_flag::gnu_extensions)
+                add_flag("-std=gnu++2a");
+            else
+                add_flag("-std=c++2a");
+            break;
+        }
     }
 
     if (flags & compile_flag::ms_compatibility)

--- a/tool/main.cpp
+++ b/tool/main.cpp
@@ -310,6 +310,8 @@ try
             config.set_flags(cppast::cpp_standard::cpp_2a, flags);
         else if (options["std"].as<std::string>() == "c++20")
             config.set_flags(cppast::cpp_standard::cpp_20, flags);
+        else if (options["std"].as<std::string>() == "c++2b")
+            config.set_flags(cppast::cpp_standard::cpp_2b, flags);
         else
         {
             print_error("invalid value '" + options["std"].as<std::string>() + "' for std flag");


### PR DESCRIPTION
Clang has had some degree of support for the C++23 working draft as far back as clang 12, this brings that in as a recognised version in our internal flags.

Minor side note - cppast still treats "latest" as C++14, is this intended behaviour, or a holdover that never got updated?