### PR TITLE
(fix) GCC array bounds checking complaint

### DIFF
--- a/src/libclang/libclang_parser.cpp
+++ b/src/libclang/libclang_parser.cpp
@@ -117,13 +117,16 @@ bool is_absolute(const std::string& file)
 
 std::string get_full_path(const detail::cxstring& dir, const std::string& file)
 {
+    DEBUG_ASSERT(!dir.empty(), detail::precondition_error_handler{},
+                 "Either file is absolute or relative to some named dir");
     if (is_absolute(file))
         // absolute file
         return file;
-    if (dir.empty())
-        // should never happen, but GCC 12.2 is not convinced. That's what exceptions are for, isn't it?
-        throw std::invalid_argument("Either file is absolute or relative to some named dir");
-    else if (dir[dir.length() - 1] != '/' && dir[dir.length() - 1] != '\\')
+// GCC fails to understand that the assertion would avoid reaching this line if dir was empty.
+#if defined __GNUC__
+#    pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+    if (dir[dir.length() - 1] != '/' && dir[dir.length() - 1] != '\\')
         // relative needing separator
         return dir.std_str() + '/' + file;
     else

--- a/src/libclang/libclang_parser.cpp
+++ b/src/libclang/libclang_parser.cpp
@@ -120,6 +120,9 @@ std::string get_full_path(const detail::cxstring& dir, const std::string& file)
     if (is_absolute(file))
         // absolute file
         return file;
+    if (dir.empty())
+        // should never happen, but GCC 12.2 is not convinced. That's what exceptions are for, isn't it?
+        throw std::invalid_argument("Either file is absolute or relative to some named dir");
     else if (dir[dir.length() - 1] != '/' && dir[dir.length() - 1] != '\\')
         // relative needing separator
         return dir.std_str() + '/' + file;


### PR DESCRIPTION
GCC 12.2 is not convinced that `dir` will never be empty.

Since that's an exceptional situation that seems almost impossible to happen, I'm throwing an exception here.

Fixes https://github.com/foonathan/cppast/issues/160