### PR TITLE
Detect C++ language from compiler arguments

### DIFF
--- a/src/libclang/libclang_parser.cpp
+++ b/src/libclang/libclang_parser.cpp
@@ -233,6 +233,21 @@ cppast::libclang_compile_config::libclang_compile_config(
         std::string exe(clang_getCString(clang_CompileCommand_getArg(cmd, 0)));
         use_c_ = (exe.find("++", 0) == std::string::npos);
 
+        if (use_c_)
+        {
+            // Try to determine the language from the compiler arguments (e.g. -std=c++11, -x c++)
+            auto argSize = clang_CompileCommands_getSize(cmd);
+            for (auto j = 0u; j <= argSize; ++j)
+            {
+                std::string arg(clang_getCString(clang_CompileCommand_getArg(cmd, j)));
+                if (arg.find("c++", 0) != std::string::npos)
+                {
+                    use_c_ = false;
+                    break;
+                }
+            }
+        }
+
         auto dir = detail::cxstring(clang_CompileCommand_getDirectory(cmd));
         parse_flags(cmd, [&](std::string flag, std::string args) {
             if (flag == "-I")


### PR DESCRIPTION
This PR improves C++ language detection by analyzing compiler arguments.

Before my PR, the language was detected by checking if "++" existed in the compiler name. This approach is incorrect in certain cases.
https://github.com/standardese/cppast/blob/5329e377ab9b9ab9309e9641f3fcda04366a449a/src/libclang/libclang_parser.cpp#L232-L234
e.g my build utility [xmake](https://xmake.io/#/) is only using `clang` not `clang++` in the `compile_commands.json` and setting `-std=c++20`.

