### PR TITLE
Make cppast compile with modern toolset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # found in the top-level directory of this distribution.
 
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 4.0)
 project(cppast VERSION 0.1.0)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/external/external.cmake
+++ b/external/external.cmake
@@ -31,7 +31,7 @@ if(build_tool)
     set(CXXOPTS_BUILD_TESTS OFF CACHE BOOL "")
 
     message(STATUS "Fetching cxxopts")
-    FetchContent_Declare(cxxopts URL https://github.com/jarro2783/cxxopts/archive/v2.2.1.zip)
+    FetchContent_Declare(cxxopts GIT_REPOSITORY https://github.com/jarro2783/cxxopts GIT_TAG origin/master)
     FetchContent_MakeAvailable(cxxopts)
 endif()
 

--- a/external/tpl/CMakeLists.txt
+++ b/external/tpl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 4.0)
 
 project(tiny-process-library)
 

--- a/include/cppast/cpp_entity_index.hpp
+++ b/include/cppast/cpp_entity_index.hpp
@@ -46,7 +46,7 @@ struct cpp_entity_id : type_safe::strong_typedef<cpp_entity_id, detail::hash_typ
 inline namespace literals
 {
     /// \returns A new [cppast::cpp_entity_id]() created from the given string.
-    inline cpp_entity_id operator"" _id(const char* str, std::size_t)
+    inline cpp_entity_id operator""_id(const char* str, std::size_t)
     {
         return cpp_entity_id(str);
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@
 # Fetch catch.
 message(STATUS "Fetching catch")
 include(FetchContent)
-FetchContent_Declare(catch URL https://github.com/catchorg/Catch2/archive/refs/tags/v2.13.9.zip)
+FetchContent_Declare(catch GIT_REPOSITORY https://github.com/catchorg/Catch2 GIT_TAG devel)
 FetchContent_MakeAvailable(catch)
 
 set(tests
@@ -42,9 +42,9 @@ foreach(file ${files})
     file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/cppast_files.hpp "\"${CMAKE_CURRENT_SOURCE_DIR}/../src/${file}\",\n")
 endforeach()
 
-add_executable(cppast_test test.cpp test_parser.hpp ${tests})
+add_executable(cppast_test test_parser.hpp ${tests})
 target_include_directories(cppast_test PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../src ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(cppast_test PUBLIC cppast Catch2)
+target_link_libraries(cppast_test PUBLIC cppast Catch2::Catch2WithMain)
 target_compile_definitions(cppast_test PUBLIC CPPAST_INTEGRATION_FILE="${CMAKE_CURRENT_SOURCE_DIR}/integration.cpp"
                                               CPPAST_COMPILE_COMMANDS="${CMAKE_BINARY_DIR}")
 

--- a/test/cpp_friend.cpp
+++ b/test/cpp_friend.cpp
@@ -14,7 +14,7 @@
 
 using namespace cppast;
 
-TEST_CASE("cpp_friend", "[!hide][clang4]")
+TEST_CASE("cpp_friend", "[.][clang4]")
 {
     auto code = R"(
 /// b

--- a/test/cpp_preprocessor.cpp
+++ b/test/cpp_preprocessor.cpp
@@ -119,6 +119,10 @@ TEST_CASE("command line macro definition")
     REQUIRE(!logger.error);
 }
 
+static bool endsWith( std::string const& s, std::string const& suffix ) {
+        return s.size() >= suffix.size() && std::equal(suffix.rbegin(), suffix.rend(), s.rbegin());
+}
+
 TEST_CASE("cpp_include_directive")
 {
     write_file("cpp_include_directive-header.hpp", R"(
@@ -149,7 +153,7 @@ b
                   REQUIRE(include.target().name() == include.name());
                   REQUIRE(include.include_kind() == cppast::cpp_include_kind::system);
                   REQUIRE(include.target().get(idx).empty());
-                  REQUIRE_THAT(include.full_path(), Catch::EndsWith("iostream"));
+                  REQUIRE(endsWith(include.full_path(), std::string("iostream")));
               }
               else if (include.name() == "cpp_include_directive-header.hpp")
               {

--- a/test/cpp_token.cpp
+++ b/test/cpp_token.cpp
@@ -3,7 +3,7 @@
 
 #include <cppast/cpp_token.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
 #include <initializer_list>

--- a/test/integration.cpp
+++ b/test/integration.cpp
@@ -7,7 +7,7 @@
 
 using namespace cppast;
 
-TEST_CASE("stdlib", "[!hide][integration]")
+TEST_CASE("stdlib", "[.][integration]")
 {
     auto code = R"(
 // list of headers from: http://en.cppreference.com/w/cpp/header
@@ -113,7 +113,7 @@ TEST_CASE("stdlib", "[!hide][integration]")
     REQUIRE(!parser.error());
 }
 
-TEST_CASE("cppast", "[!hide][integration]")
+TEST_CASE("cppast", "[integration]")
 {
     const char* files[] = {
 #include <cppast_files.hpp>

--- a/test/libclang_parser.cpp
+++ b/test/libclang_parser.cpp
@@ -1,7 +1,7 @@
 // Copyright (C) 2017-2023 Jonathan Müller and cppast contributors
 // SPDX-License-Identifier: MIT
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <cppast/libclang_parser.hpp>
 

--- a/test/parser.cpp
+++ b/test/parser.cpp
@@ -3,7 +3,7 @@
 
 #include <cppast/parser.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace cppast;
 

--- a/test/preprocessor.cpp
+++ b/test/preprocessor.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <fstream>
 
 #include "libclang/preprocessor.hpp"
@@ -8,7 +8,7 @@
 
 using namespace cppast;
 
-TEST_CASE("preprocessor escaped character", "[!hide][clang4]")
+TEST_CASE("preprocessor escaped character", "[.][clang4]")
 {
     write_file("ppec.hpp", R"(
 )");

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,5 +1,0 @@
-// Copyright (C) 2017-2023 Jonathan Müller and cppast contributors
-// SPDX-License-Identifier: MIT
-
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>

--- a/test/test_parser.hpp
+++ b/test/test_parser.hpp
@@ -6,7 +6,7 @@
 
 #include <fstream>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <cppast/code_generator.hpp>
 #include <cppast/cpp_class.hpp>


### PR DESCRIPTION
Fixed the following:
 - updated the cmake_minimum_required() target version to 4.0 : 3.x deprecated
 - Upgraded external repos to use the latest from the 3d party libraries
 - Upgraded Catch2 tests to use the newer test infra
 - Removed obsolete [!hide] from the test descriptions
 - fixed a warning in "" operator overload.