### PR TITLE
Relax cmake version requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # found in the top-level directory of this distribution.
 
-cmake_minimum_required(VERSION 4.0)
+cmake_minimum_required(VERSION 3.5)
 project(cppast VERSION 0.1.0)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/external/tpl/CMakeLists.txt
+++ b/external/tpl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 4.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(tiny-process-library)
 


### PR DESCRIPTION
so we can build with Ubuntu 24.04 (which has cmake 3.28.0.) I guess 3.5.0 is good enough, though I didn't check.